### PR TITLE
Remove extra parenthesis

### DIFF
--- a/src/epub/text/tao-te-ching.xhtml
+++ b/src/epub/text/tao-te-ching.xhtml
@@ -871,7 +871,7 @@
 					</p>
 				</div>
 				<p>On this account the sage feels a difficulty (as to what to do in the former case).</p>
-				<p>It is the way of Heaven not to strive, and yet it skilfully overcomes; not to speak, and yet it is skilful in (obtaining a reply; does not call, and yet men come to it of themselves. Its demonstrations are quiet, and yet its plans are skilful and effective. The meshes of the net of Heaven are large; far apart, but letting nothing escape.<a href="endnotes.xhtml#note-109" id="noteref-109" epub:type="noteref">109</a></p>
+				<p>It is the way of Heaven not to strive, and yet it skilfully overcomes; not to speak, and yet it is skilful in obtaining a reply; does not call, and yet men come to it of themselves. Its demonstrations are quiet, and yet its plans are skilful and effective. The meshes of the net of Heaven are large; far apart, but letting nothing escape.<a href="endnotes.xhtml#note-109" id="noteref-109" epub:type="noteref">109</a></p>
 			</section>
 			<section id="chapter-74" epub:type="chapter">
 				<h3 epub:type="ordinal z3998:roman">LXXIV</h3>


### PR DESCRIPTION
Fix the actual problem. [Gutenberg](https://www.gutenberg.org/files/216/216-h/216-h.htm) doesn't have this extra parenthesis:

>  not to speak, and yet it is skilful in obtaining a reply