### PR TITLE
Add alternate titles

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -30,6 +30,12 @@
 		<link href="onix.xml" media-type="application/xml" properties="onix" rel="record"/>
 		<dc:title id="title">Tao Te Ching</dc:title>
 		<meta property="file-as" refines="#title">Tao Te Ching</meta>
+		<meta property="se:alternate-title" refines="#title">Dao De Jing</meta>
+		<meta property="se:alternate-title" refines="#title">Daode Jing</meta>
+		<meta property="se:alternate-title" refines="#title">Daodejing</meta>
+		<meta property="se:alternate-title" refines="#title">Laozi</meta>
+		<meta property="se:alternate-title" refines="#title">Lao Tzu</meta>
+		<meta property="se:alternate-title" refines="#title">Lao-Tze</meta>
 		<dc:subject id="subject-1">Taoism</dc:subject>
 		<meta property="authority" refines="#subject-1">LCSH</meta>
 		<meta property="term" refines="#subject-1">sh85132392</meta>


### PR DESCRIPTION
This book has a lot of alternate titles, in part because of different romanization schemes.

"Dao De Jing," "Daode Jing," and "Daodejing" are all based on the Pinyin romanization of the characters 道德經, with the only difference being in where you insert spaces. I think all of these three schemes are valid and you can find different places where all three are used. Since Pinyin is now the most common scheme of romanizing Chinese characters, I think adding these for navigability is a must.

Also, sometimes the book is titled after Laozi himself. It might seem a little silly for a modern Western reader to think of the book as "_Laozi_ by Laozi," but that was the convention of naming books in the cultural context in which this book was written. For the purposes of completeness I added "Laozi" and "Lao Tzu" and "Lao-Tse", the most common romanizations of that name (and hence that version of this book's title).